### PR TITLE
Add support for IRC invite

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -41,9 +41,9 @@ function Bot(options) {
 Bot.prototype.attachListeners = function() {
   this.client.addListener('registered', function(message) {
     logger.debug('Registered event: ', message);
-    this.autoSendCommands.forEach(function(element, index, array) {
+    this.autoSendCommands.forEach(function(element) {
       this.client.send.apply(this.client, element);
-    }.bind(this));
+    }, this);
   }.bind(this));
 
   this.client.addListener('message', function(from, to, message) {
@@ -56,14 +56,14 @@ Bot.prototype.attachListeners = function() {
   });
 
   this.client.addListener('invite', function(channel, from, message) {
-    logger.debug('Received invite', channel, from, message);
-    if (this.opt.channels.indexOf(channel) > -1) {
-      this.join(channel);
+    logger.debug('Received invite:', channel, from, message);
+    if (this.channels.indexOf(channel) > -1) {
+      this.client.join(channel);
       logger.debug('Joining channel:', channel);
     } else {
       logger.debug('Channel not found in config, not joining:', channel);
     }
-  });
+  }.bind(this));
 };
 
 function ensureHash(channel) {

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -50,6 +50,11 @@ Bot.prototype.attachListeners = function() {
   this.client.addListener('error', function(error) {
     logger.error('Received error event from IRC', error);
   });
+
+  this.client.addListener('invite', function(channel, from, message) {
+    logger.debug('Received invite', channel, from, message);
+    this.join(channel);
+  });
 };
 
 function ensureHash(channel) {

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -25,6 +25,7 @@ function Bot(options) {
   this.incomingURL = options.incomingURL;
   this.channelMapping = validateChannelMapping(options.channelMapping);
   this.channels = _.values(this.channelMapping);
+  this.autoSendCommands = options.autoSendCommands;
 
   logger.debug('Connecting to IRC');
   this.client = new irc.Client(this.server, this.nickname, {
@@ -33,8 +34,6 @@ function Bot(options) {
     channels: this.channels
   });
 
-  this.client.autosendcmd = options.autosendcmd;
-
   this.slackGateway = new SlackGateway(this.incomingURL, this.channelMapping);
   this.attachListeners();
 }
@@ -42,10 +41,10 @@ function Bot(options) {
 Bot.prototype.attachListeners = function() {
   this.client.addListener('registered', function(message) {
     logger.debug('Registered event: ', message);
-    for (var i = 0, len = this.autosendcmd.length; i < len; i++) {
-      this.send.apply(this, this.autosendcmd[i]);
-    }
-  });
+    this.autoSendCommands.forEach(function(element, index, array) {
+      this.client.send.apply(this.client, element);
+    }.bind(this));
+  }.bind(this));
 
   this.client.addListener('message', function(from, to, message) {
     logger.debug('Received a message from Slack', from, to, message);

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -25,7 +25,7 @@ function Bot(options) {
   this.incomingURL = options.incomingURL;
   this.channelMapping = validateChannelMapping(options.channelMapping);
   this.channels = _.values(this.channelMapping);
-  this.autoSendCommands = options.autoSendCommands;
+  this.autoSendCommands = options.autoSendCommands || [];
 
   logger.debug('Connecting to IRC');
   this.client = new irc.Client(this.server, this.nickname, {

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -33,6 +33,8 @@ function Bot(options) {
     channels: this.channels
   });
 
+  this.client.autosendcmd = options.autosendcmd;
+
   this.slackGateway = new SlackGateway(this.incomingURL, this.channelMapping);
   this.attachListeners();
 }
@@ -40,6 +42,9 @@ function Bot(options) {
 Bot.prototype.attachListeners = function() {
   this.client.addListener('registered', function(message) {
     logger.debug('Registered event: ', message);
+    for (var i = 0, len = this.autosendcmd.length; i < len; i++) {
+      this.send.apply(this, this.autosendcmd[i]);
+    }
   });
 
   this.client.addListener('message', function(from, to, message) {
@@ -53,7 +58,12 @@ Bot.prototype.attachListeners = function() {
 
   this.client.addListener('invite', function(channel, from, message) {
     logger.debug('Received invite', channel, from, message);
-    this.join(channel);
+    if (this.opt.channels.indexOf(channel) > -1) {
+      this.join(channel);
+      logger.debug('Joining channel:', channel);
+    } else {
+      logger.debug('Channel not found in config, not joining:', channel);
+    }
   });
 };
 

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -30,8 +30,8 @@ describe('Bot', function() {
     var bots = createBots();
     bots.length.should.equal(2);
 
-    // 3 listeners per bot, two bots = 6
-    addListenerStub.should.have.callCount(6);
+    // 4 listeners per bot, two bots = 8
+    addListenerStub.should.have.callCount(8);
   });
 
   it('should work when given an object as a config file', function() {


### PR DESCRIPTION
The IRC channel I want to mirror with slack is invite-only. This change makes slack-irc respond to invite commands, automatically joining any channel it is invited to.