### PR TITLE
Adds support for IRC-Actions

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -39,6 +39,36 @@ function Bot(options) {
   this.attachListeners();
 }
 
+Bot.prototype.sendRawToSlack = function(obj){
+    var slackChannelName = this.invertedMapping[obj.args[0]];
+    if (slackChannelName) {
+        var slackChannel = this.slack.getChannelGroupOrDMByName(slackChannelName);
+
+        if (!slackChannel) {
+            logger.info(
+                'Tried to send a message to a channel the bot isn\'t in: ' + slackChannelName
+            );
+            return;
+        }
+        
+        var msg = obj.args[1];
+        if (! msg) {
+            return;
+        }
+        
+        var message = {
+            text: obj.args[1].replace(/ACTION/, obj.nick),
+            username: obj.nick,
+            parse: 'full',
+            icon_url: 'http://api.adorable.io/avatars/48/' + obj.nick + '.png'
+        };
+        
+        logger.debug('Sending message to Slack', message);
+        console.log(message);
+        slackChannel.postMessage(message);
+    }
+}
+
 Bot.prototype.sendToSlack = function(author, channel, text) {
   var slackChannelName = this.invertedMapping[channel];
   if (slackChannelName) {
@@ -89,6 +119,8 @@ Bot.prototype.attachListeners = function() {
   }.bind(this));
 
   this.ircClient.on('message', this.sendToSlack.bind(this));
+  
+  this.ircClient.on('raw', this.sendRawToSlack.bind(this));
 
   this.ircClient.on('invite', function(channel, from, message) {
     logger.debug('Received invite:', channel, from, message);


### PR DESCRIPTION
This PR adds a way to support action-messages from IRC

So an IRC message of ```/me types in IRC``` will be send as ```<username> types in IRC``` 

Sorry, no tests :frowning: 