### PR TITLE
Add commandCharacters option

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,10 @@ as long as they're present in the channel mapping.
     "ircOptions": { // Optional node-irc options
       "floodProtection": false, // On by default
       "floodProtectionDelay": 1000 // 500 by default
-    }
+    },
+    // Makes the bot hide the username prefix for messages that start
+    // with one of these characters (commands):
+    "commandCharacters": ["!", "."]
   }
 ]
 ```

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -26,7 +26,7 @@ function Bot(options) {
   this.server = options.server;
   this.nickname = options.nickname;
   this.ircOptions = options.ircOptions;
-
+  this.commandCharacters = options.commandCharacters || [];
   this.channels = _.values(options.channelMapping);
 
   this.channelMapping = {};
@@ -131,6 +131,10 @@ Bot.prototype.parseText = function(text) {
     });
 };
 
+Bot.prototype.isCommandMessage = function(message) {
+  return this.commandCharacters.indexOf(message[0]) !== -1;
+};
+
 Bot.prototype.sendToIRC = function(message) {
   var channel = this.slack.getChannelGroupOrDMByID(message.channel);
   if (!channel) {
@@ -142,10 +146,18 @@ Bot.prototype.sendToIRC = function(message) {
   var channelName = channel.is_channel ? '#' + channel.name : channel.name;
   var ircChannel = this.channelMapping[channelName];
 
-  logger.debug('chan', channelName, this.channelMapping[channelName]);
+  logger.debug('Channel Mapping', channelName, this.channelMapping[channelName]);
   if (ircChannel) {
     var user = this.slack.getUserByID(message.user);
-    var text = '<' + user.name + '> ' + this.parseText(message.getBody());
+
+    var body = message.getBody();
+    var text;
+    if (this.isCommandMessage(body)) {
+      text = body;
+    } else {
+      text = '<' + user.name + '> ' + body;
+    }
+
     logger.debug('Sending message to IRC', channelName, text);
     this.ircClient.say(ircChannel, text);
   }

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -153,6 +153,8 @@ Bot.prototype.sendToIRC = function(message) {
     var body = message.getBody();
     var text;
     if (this.isCommandMessage(body)) {
+      var prelude = 'Command sent from Slack by ' + user.name + ':';
+      this.ircClient.say(ircChannel, prelude);
       text = body;
     } else {
       text = '<' + user.name + '> ' + body;

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -109,4 +109,17 @@ describe('Bot', function() {
     this.bot.parseText(':smile:').should.equal(':)');
     this.bot.parseText(':train:').should.equal(':train:');
   });
+
+  it('should hide usernames for commands', function() {
+    var text = '!test command';
+    var message = {
+      channel: 'slack',
+      getBody: function() {
+        return text;
+      }
+    };
+
+    this.bot.sendToIRC(message);
+    ClientStub.prototype.say.should.have.been.calledWith('#irc', text);
+  });
 });

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -120,6 +120,9 @@ describe('Bot', function() {
     };
 
     this.bot.sendToIRC(message);
-    ClientStub.prototype.say.should.have.been.calledWith('#irc', text);
+    ClientStub.prototype.say.getCall(0).args.should.deep.equal([
+      '#irc', 'Command sent from Slack by testuser:'
+    ]);
+    ClientStub.prototype.say.getCall(1).args.should.deep.equal(['#irc', text]);
   });
 });

--- a/test/fixtures/single-test-config.json
+++ b/test/fixtures/single-test-config.json
@@ -2,6 +2,7 @@
   "nickname": "test",
   "server": "irc.bottest.org",
   "token": "testtoken",
+  "commandCharacters": ["!", "."],
   "autoSendCommands": [
     ["MODE", "test", "+x"],
     ["AUTH", "test", "password"]


### PR DESCRIPTION
Makes the bot hide the username prefix (on IRC) for messages that start with one of the characters provided in `commandCharacters`. This makes it possible to communicate with IRC chat bots from Slack.
Fixes #43.