### PR TITLE
Improved text formatting in both directions

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -112,6 +112,9 @@ Bot.prototype.parseText = function(text) {
     .replace(/<@(U\w+)\|?(\w+)?>/g, function(match, userId, readable) {
       return readable || '@' + this.slack.getUserByID(userId).name;
     }.bind(this))
+    .replace(/<mailto:([^\|]+)(\|[^>]+)?>/g, function(match, email, name) {
+      return email;
+    })
     .replace(/<(?!!)(\S+)>/g, function(match, link) {
       return link;
     })

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -115,7 +115,7 @@ Bot.prototype.parseText = function(text) {
     .replace(/<mailto:([^\|]+)(\|[^>]+)?>/g, function(match, email, name) {
       return email;
     })
-    .replace(/<(?!!)(\S+)>/g, function(match, link) {
+    .replace(/<(?!!)([^\|]+)(\|[^>]+)?>/g, function(match, link, label) {
       return link;
     })
     .replace(/<!(\w+)\|?(\w+)?>/g, function(match, command, label) {

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -118,6 +118,12 @@ Bot.prototype.parseText = function(text) {
     .replace(/<(?!!)([^\|]+)(\|[^>]+)?>/g, function(match, link, label) {
       return link;
     })
+    .replace(/(^|\s)\*\b(\S.+?\S)\b\*(?=\s|$)/gm, function(match, before, text, after) {
+      return before + String.fromCharCode(02) + text + String.fromCharCode(02);
+    })
+    .replace(/\b\_(\S.+?\S)\_\b/gm, function(match,  text) {
+      return String.fromCharCode(0x1f) + text + String.fromCharCode(0x1f);
+    })
     .replace(/<!(\w+)\|?(\w+)?>/g, function(match, command, label) {
       if (label) {
         return '<' + label + '>';
@@ -131,6 +137,30 @@ Bot.prototype.parseText = function(text) {
       }
 
       return match;
+    });
+};
+
+Bot.prototype.parseMessage = function(message) {
+  return message
+
+    // bold
+    .replace(/(\u0002)([^\u0002]+)(\u0002|\u000f|$)/g, function(match, opener, text, end) {
+      return '*' + text + '*';
+    })
+
+    // italic
+    .replace(/(\u001d)([^\u001d]+)(\u001d|\u000f|$)/g, function(match, opener, text, end) {
+      return '_' + text + '_';
+    })
+
+    // underlined
+    .replace(/(\u001f)([^\u001f]+)(\u001f|\u000f|$)/g, function(match, opener, text, end) {
+      return '_' + text + '_';
+    })
+
+    // remove colour
+    .replace(/(\u0003[0-9]{0,2},?[0-9]{0,2})([^\u0003]+)(\u0003|\u000f|$)/g, function(match, opener, text, end) {
+      return text;
     });
 };
 
@@ -179,7 +209,7 @@ Bot.prototype.sendToSlack = function(author, channel, text) {
     }
 
     var message = {
-      text: text,
+      text: this.parseMessage(text),
       username: author,
       parse: 'full',
       icon_url: 'http://api.adorable.io/avatars/48/' + author + '.png'


### PR DESCRIPTION
Currently, text formatting is not converted into the native formats of the recipient in both directions. This PR aims to add support for the basics, which is bold, underlined and italic. Colours are not yet supported.

It also improves the output of URLs and mails on IRC client side, which currently do not support the pipe syntax by Slack and thus urls like `<http://google.com|google.com>` end up as `http://google.com|google.com`in IRC instead of just `http://google.com`. Same for mails, where the mailto: prefix is also being removed.

I wasn't sure how to name the parsing method for Slack messages. Ideally the old parseText function would be renamed to parseTextForIRC or alike, but I didn't want to break backwards compat. Please tell me what you prefer here and I'll adjust the PR accordingly.