### PR TITLE
Add muteSlackbot to prevent messages from Slackbot going to IRC

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,10 @@ Valid JSON cannot contain comments, so remember to remove them first!
     },
     // Makes the bot hide the username prefix for messages that start
     // with one of these characters (commands):
-    "commandCharacters": ["!", "."]
+    "commandCharacters": ["!", "."],
+    // Prevent messages posted by Slackbot (e.g. Slackbot responses)
+    // from being posted into the IRC channel:
+    "muteSlackbot": true // Off by default
   }
 ]
 ```

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -30,6 +30,7 @@ class Bot {
     this.ircOptions = options.ircOptions;
     this.commandCharacters = options.commandCharacters || [];
     this.channels = _.values(options.channelMapping);
+    this.muteSlackbot = options.muteSlackbot || false;
 
     this.channelMapping = {};
 
@@ -152,6 +153,11 @@ class Bot {
       return;
     }
 
+    if (this.muteSlackbot && message.user === 'USLACKBOT') {
+      logger.debug(`Muted message from Slackbot: "${message.text}"`);
+      return;
+    }
+
     const channelName = channel.is_channel ? `#${channel.name}` : channel.name;
     const ircChannel = this.channelMapping[channelName];
 
@@ -168,7 +174,6 @@ class Bot {
       } else if (message.subtype === 'me_message') {
         text = `Action: ${user.name} ${text}`;
       }
-
       logger.debug('Sending message to IRC', channelName, text);
       this.ircClient.say(ircChannel, text);
     }

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -121,6 +121,34 @@ describe('Bot', function() {
     ClientStub.prototype.say.should.not.have.been.called;
   });
 
+  it('should send messages from slackbot if slackbot muting is off',
+  function() {
+    const text = 'A message from Slackbot';
+    const message = {
+      user: 'USLACKBOT',
+      getBody() {
+        return text;
+      }
+    };
+
+    this.bot.sendToIRC(message);
+    const ircText = `<testuser> ${text}`;
+    ClientStub.prototype.say.should.have.been.calledWith('#irc', ircText);
+  });
+
+  it('should not send messages from slackbot to irc if slackbot muting is on',
+  function() {
+    this.bot.muteSlackbot = true;
+    const message = {
+      user: 'USLACKBOT',
+      getBody() {
+        return 'A message from Slackbot';
+      }
+    };
+    this.bot.sendToIRC(message);
+    ClientStub.prototype.say.should.not.have.been.called;
+  });
+
   it('should parse text from slack when sending messages', function() {
     const text = '<@USOMEID> <@USOMEID|readable>';
     const message = {


### PR DESCRIPTION
Slackbot can be customized to respond with custom phrases based on a trigger word. The `muteSlackbot` option prevents Slack messages originating from Slackbot being echoed into IRC.

The option is opt-in and is off by default.