### PR TITLE
Add helper to decorate 'bare' Slack usernames with @

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -5,6 +5,7 @@ import Slack from 'slack-client';
 import { ConfigurationError } from './errors';
 import emojis from '../assets/emoji.json';
 import { validateChannelMapping } from './validators';
+import { decorateBareUsernameWithAt } from './helpers';
 
 const ALLOWED_SUBTYPES = ['me_message'];
 const REQUIRED_FIELDS = ['server', 'nickname', 'channelMapping', 'token'];
@@ -185,8 +186,16 @@ class Bot {
         return;
       }
 
+      const currentChannelUsernames = slackChannel.members.map( member =>
+        this.slack.getUserByID(member).name
+      );
+
+      const mappedText = currentChannelUsernames.reduce((current, username) =>
+        decorateBareUsernameWithAt(username, current)
+      , text);
+
       const message = {
-        text: text,
+        text: mappedText,
         username: author,
         parse: 'full',
         icon_url: `http://api.adorable.io/avatars/48/${author}.png`

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -26,3 +26,22 @@ export function createBots(configFile) {
 
   return bots;
 }
+
+/**
+ * Returns occurances of a current channel member's name with `@${name}`
+ * @return {string}
+ */
+
+
+export function decorateBareUsernameWithAt(user, text) {
+  const words = text.split(' ');
+  return words.map( word => {
+    // if the user is already prefixed by @, don't replace
+    if (word.indexOf(`@${user}`) === 0) {
+      return word;
+    }
+
+    const regexp = new RegExp(`^${user}\\b`);
+    return word.replace(regexp, `@${user}`);
+  }).join(' ');
+}

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -81,6 +81,23 @@ describe('Bot', function() {
     ChannelStub.prototype.postMessage.should.not.have.been.called;
   });
 
+  it('should replace a bare username if the user is in-channel', function() {
+    const message = {
+      text: 'testuser should be replaced in the message',
+      username: 'testuser',
+      parse: 'full',
+      icon_url: 'http://api.adorable.io/avatars/48/testuser.png'
+    };
+
+    const expected = {
+      ...message,
+      text: '@testuser should be replaced in the message'
+    };
+
+    this.bot.sendToSlack(message.username, '#IRC', message.text);
+    ChannelStub.prototype.postMessage.should.have.been.calledWith(expected);
+  });
+
   it('should send correct messages to irc', function() {
     const text = 'testmessage';
     const message = {

--- a/test/stubs/channel-stub.js
+++ b/test/stubs/channel-stub.js
@@ -6,6 +6,7 @@ class ChannelStub extends EventEmitter {
     super();
     this.name = 'slack';
     this.is_channel = true;
+    this.members = ['testuser'];
   }
 }
 

--- a/test/username-decorator.test.js
+++ b/test/username-decorator.test.js
@@ -1,0 +1,34 @@
+import chai from 'chai';
+import { decorateBareUsernameWithAt } from '../lib/helpers';
+chai.should();
+
+describe('Bare Slack Username Replacement', () => {
+  it('should replace `username` with `@username`', () => {
+    const message = 'hey username, check this out';
+    const expected = 'hey @username, check this out';
+    const result = decorateBareUsernameWithAt('username', message);
+    result.should.equal(expected);
+  });
+
+  it('should replace when followed by a character', () => {
+    const message = 'username: go check this out';
+    const expected = '@username: go check this out';
+    const result = decorateBareUsernameWithAt('username', message);
+    result.should.equal(expected);
+  });
+
+  it('should not replace `username` in a url with a protocol', () => {
+    const message = 'the repo is https://github.com/username/foo';
+    decorateBareUsernameWithAt('username', message).should.equal(message);
+  });
+
+  it('should not replace `username` in a url without a protocol', () => {
+    const message = 'the repo is github.com/username/foo';
+    decorateBareUsernameWithAt('username', message).should.equal(message);
+  });
+
+  it('should not replace a @-prefixed username', () => {
+    const message = 'hey @username, check this out';
+    decorateBareUsernameWithAt('username', message).should.equal(message);
+  });
+});


### PR DESCRIPTION
Most IRC clients will highlight/notify on occurrences of your username/nick, without requiring that it be prefixed by a @ character. Slack normally works this way as well; if a human user types either 'grahamb' or '@grahamb' into Slack, I'll get a notification.

Bot users, however, only trigger notifications when the username has a @-prefix. This appears to be by design; see https://twitter.com/kylefuller/status/538475098416480256 for more details. It's unlikely that Slack will change this behaviour.

This commit adds a helper function to transform occurrences of a 'bare' username to one prefixed by an @ character. For example, "Hey grahamb, are you around?" gets transformed to "Hey @grahamb, are you around?", and thus triggers a notification. It does not replace inside a URL, so http://github.com/grahamb/slack-irc gets left alone.

Tests have been added for the decorator itself, as well as its implementation inside the Bot class. When a Bot receives a message and runs `sendToSlack`, it gets the usernames of the Slack users currently in the Slack channel, and runs `decorateBareUsernameWithAt` against each user and the message text.