### PR TITLE
option to set real name in irc client

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -28,6 +28,7 @@ class Bot {
 
     this.server = options.server;
     this.nickname = options.nickname;
+    this.realname = options.realname || options.nickname;
     this.ircOptions = options.ircOptions;
     this.ircStatusNotices = options.ircStatusNotices || {};
     this.commandCharacters = options.commandCharacters || [];
@@ -51,7 +52,7 @@ class Bot {
 
     const ircOptions = {
       userName: this.nickname,
-      realName: this.nickname,
+      realName: this.realname,
       channels: this.channels,
       floodProtection: true,
       floodProtectionDelay: 500,


### PR DESCRIPTION
I want to put information about the slack channel visible to IRC. Based on API, it looks like `realName` is only place to do that. This defaults to current behavior if not defined.