### PR TITLE
support bot messages with message attachment fallback

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -7,7 +7,7 @@ import emojis from '../assets/emoji.json';
 import { validateChannelMapping } from './validators';
 import { highlightUsername } from './helpers';
 
-const ALLOWED_SUBTYPES = ['me_message'];
+const ALLOWED_SUBTYPES = ['me_message', 'bot_message'];
 const REQUIRED_FIELDS = ['server', 'nickname', 'channelMapping', 'token'];
 
 /**
@@ -145,6 +145,7 @@ class Bot {
   }
 
   parseText(text) {
+    if (typeof(text) == "undefined") return "";
     const { dataStore } = this.slack.rtm;
     return text
       .replace(/\n|\r\n|\r/g, ' ')
@@ -209,6 +210,10 @@ class Bot {
         text = `<${user.name}> ${text}`;
       } else if (message.subtype === 'me_message') {
         text = `Action: ${user.name} ${text}`;
+      } else if (message.subtype === 'bot_message' && "attachments" in message && message.attachments.length > 0 && "fallback" in message.attachments[0]) {
+        text = `\x0303${message.attachments[0].fallback.replace(/\|/g, " ")}\x03`;
+      } else if (message.subtype === 'bot_message') {
+        return;
       }
       logger.debug('Sending message to IRC', channelName, text);
       this.ircClient.say(ircChannel, text);


### PR DESCRIPTION
Just wanted to share my latest patch for supporting bot messages. [Related conversation for reference](https://github.com/ekmartin/slack-irc/issues/50). I have been using this with github and twitter integration in slack.

Here is the breakdown:

* Expanded **ALLOWED_SUBTYPES** to include 'bot_message'
* parseText() handles undefined input because some messages don't have the text field set (twitter)
* Support bot_messages with **attachments** that have "fallback" messages. Fallback messages are short text only messages provided by the slack integration app for printing in text-only situations.
* Minor **formatting** for fallback messages to make \<URL|desc\> markup click-able by replacing "|". And also adding IRC coloring escape code because color is nice.
* Ignore bot_messages without attachments. This prevents echos from the slack-irc bot itself. This would also exclude slack integrations that dont use fallback. At least this isnt an issue so far, and these bot messages are already ignored anyway.

So theres no additional config to support this. The change basically just means that bot messages are still ignored, except when they contain an attachment with a fallback message. So I hope that this is mostly an additive change without any negative side-effects. Thanks for your consideration!