### PR TITLE
fix highlight problem with common usernames

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -32,9 +32,12 @@ export function createBots(configFile) {
  * @return {string}
  */
 export function highlightUsername(user, text) {
+  // if the username is "a", "an", "it", or "the", don't replace
+  if (user === 'a' || user === 'an' || user === 'the' || user === 'it') {
+    return text;
+  }
   const words = text.split(' ');
   const userRegExp = new RegExp(`^${user}[,.:!?]?$`);
-
   return words.map(word => {
     // if the user is already prefixed by @, don't replace
     if (word.indexOf(`@${user}`) === 0) {

--- a/test/username-decorator.test.js
+++ b/test/username-decorator.test.js
@@ -31,4 +31,9 @@ describe('Bare Slack Username Replacement', () => {
     const message = 'hey @username, check this out';
     highlightUsername('username', message).should.equal(message);
   });
+
+  it('should not replace a username that is a common word', () => {
+    const message = 'this is just a regular sentence';
+    highlightUsername('a', message).should.equal(message);
+  });
 });


### PR DESCRIPTION
Very hacky attempt at not highlighting four common english words just because someone in the slack has selected one of them as a username.