### PR TITLE
Handle entity escaping later in received messages.

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -148,9 +148,6 @@ class Bot {
     const { dataStore } = this.slack.rtm;
     return text
       .replace(/\n|\r\n|\r/g, ' ')
-      .replace(/&amp;/g, '&')
-      .replace(/&lt;/g, '<')
-      .replace(/&gt;/g, '>')
       .replace(/<!channel>/g, '@channel')
       .replace(/<!group>/g, '@group')
       .replace(/<!everyone>/g, '@everyone')
@@ -173,7 +170,10 @@ class Bot {
 
         return match;
       })
-      .replace(/<.+?\|(.+?)>/g, (match, readable) => readable);
+      .replace(/<.+?\|(.+?)>/g, (match, readable) => readable)
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&amp;/g, '&');
   }
 
   isCommandMessage(message) {

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -283,6 +283,16 @@ describe('Bot', function () {
       .should.equal('<somecommand> <readable>');
   });
 
+  it('should handle entity-encoded messages from slack', function () {
+    this.bot.parseText('&amp;lt;&amp;gt;').should.equal('&lt;&gt;');
+    this.bot.parseText('&lt;@UNONEID&gt;').should.equal('<@UNONEID>');
+    this.bot.parseText('&lt;#CNONEID&gt;').should.equal('<#CNONEID>');
+    this.bot.parseText('&lt;!channel&gt;').should.equal('<!channel>');
+    this.bot.parseText('&lt;<http://example.com|example.com>&gt;').should.equal('<example.com>');
+    this.bot.parseText('java.util.List&lt;java.lang.String&gt;')
+      .should.equal('java.util.List<java.lang.String>');
+  });
+
   it('should parse emojis correctly', function () {
     this.bot.parseText(':smile:').should.equal(':)');
     this.bot.parseText(':train:').should.equal(':train:');


### PR DESCRIPTION
- Move entity decoding to be last replace operation to avoid limited
value injection and denial of service.
- Re-arrange entity decoding to avoid them chain-decoding: amp must be
decoded last as ampersand is included in lt and gt matches.
- Add test-cases for escaped messages.