### PR TITLE
Update use as node module example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ It can also be used as a node module:
 ```js
 var slackIRC = require('slack-irc');
 var config = require('./config.json');
-slackIRC(config);
+slackIRC.default(config);
 ```
 
 ## Configuration


### PR DESCRIPTION
In my testing, I found the example given for using slack-irc as a node module is incorrect. 

`index.js` exports one property (`default`) that points to `_helpers.createBots`