### PR TITLE
Report file uploads to IRC

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -7,7 +7,7 @@ import emojis from '../assets/emoji.json';
 import { validateChannelMapping } from './validators';
 import { highlightUsername } from './helpers';
 
-const ALLOWED_SUBTYPES = ['me_message'];
+const ALLOWED_SUBTYPES = ['me_message', 'file_share'];
 const REQUIRED_FIELDS = ['server', 'nickname', 'channelMapping', 'token'];
 
 /**
@@ -208,6 +208,11 @@ class Bot {
         this.ircClient.say(ircChannel, prelude);
       } else if (!message.subtype) {
         text = `<${user.name}> ${text}`;
+      } else if (message.subtype === 'file_share') {
+        text = `<${user.name}> File uploaded ${message.file.permalink} / ${message.file.permalink_public}`;
+        if (message.file.initial_comment) {
+          text += ` - ${message.file.initial_comment.comment}`;
+        }
       } else if (message.subtype === 'me_message') {
         text = `Action: ${user.name} ${text}`;
       }

--- a/test/bot-events.test.js
+++ b/test/bot-events.test.js
@@ -77,6 +77,19 @@ describe('Bot Events', function () {
     this.bot.sendToIRC.should.have.been.calledWithExactly(message);
   });
 
+  it('should send files to irc if correct', function () {
+    const message = {
+      type: 'message',
+      subtype: 'file_share',
+      file: {
+        permalink: 'test',
+        permalink_public: 'test'
+      }
+    };
+    this.bot.slack.rtm.emit('message', message);
+    this.bot.sendToIRC.should.have.been.calledWithExactly(message);
+  });
+
   it('should not send messages to irc if the type isn\'t message', function () {
     const message = {
       type: 'notmessage'

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -251,6 +251,28 @@ describe('Bot', function () {
     ClientStub.prototype.say.should.have.been.calledWith('#irc', ircText);
   });
 
+  it('should send files to irc', function () {
+    const link1 = 'test1';
+    const link2 = 'test2';
+    const text = 'testcomment';
+    const message = {
+      text: '',
+      channel: 'slack',
+      subtype: 'file_share',
+      file: {
+        permalink: link1,
+        permalink_public: link2,
+        initial_comment: {
+          comment: text
+        }
+      }
+    };
+
+    this.bot.sendToIRC(message);
+    const ircText = `<testuser> File uploaded ${link1} / ${link2} - ${text}`;
+    ClientStub.prototype.say.should.have.been.calledWith('#irc', ircText);
+  });
+
   it('should not send messages to irc if the channel isn\'t in the channel mapping',
   function () {
     this.bot.slack.rtm.dataStore.getChannelGroupOrDMById = () => null;


### PR DESCRIPTION
This handles file_share message subtype which is sent when e.g. screenshot is pasted to Slack channel. It shows both Slack-internal link and public link. For the public link to work Slack config "Enable public file URL creation" must be enabled and file uploader must also click "Create external link" on the file.

Looks like this in IRC channel
```
20:58 < slack> <aketzu> File uploaded 
             https://team.slack.com/files/aketzu/F60UD9R2L/pasted_image_at_2017_04_18_08_57_pm.png / 
             https://slack-files.com/T0LK1LT6W-F60UD9R2L-8fb1c182e4 - comment here
```

Fixes #22