### PR TITLE
Add support for relaying bridged users

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Valid JSON cannot contain comments, so remember to remove them first!
     // Prevent messages posted by Slackbot (e.g. Slackbot responses)
     // from being posted into the IRC channel:
     "muteSlackbot": true, // Off by default
+    "muteBridgedUsers": false, // On by default
     // Sends messages to Slack whenever a user joins/leaves an IRC channel:
     "ircStatusNotices": {
       "join": false, // Don't send messages about joins

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -35,6 +35,7 @@ class Bot {
     this.commandCharacters = options.commandCharacters || [];
     this.channels = _.values(options.channelMapping);
     this.muteSlackbot = options.muteSlackbot || false;
+    this.muteBridgedUsers = options.muteBridgedUsers || true;
     this.muteUsers = {
       slack: [],
       irc: [],
@@ -100,10 +101,13 @@ class Bot {
     });
 
     this.slack.rtm.on('message', (message) => {
-      // Ignore bot messages and people leaving/joining
-      if (message.type === 'message' &&
-        (!message.subtype || ALLOWED_SUBTYPES.indexOf(message.subtype) > -1)) {
-        this.sendToIRC(message);
+        // Ignore bot messages and people leaving/joining
+      if (message.type === 'message') {
+        if (!message.subtype || ALLOWED_SUBTYPES.indexOf(message.subtype) > -1) {
+          this.sendToIRC(message);
+        } else if (message.subtype === 'bot_message' && message.username) {
+          this.sendToIRC(message);
+        }
       }
     });
 
@@ -207,6 +211,11 @@ class Bot {
       return;
     }
 
+    if (this.muteBridgedUsers && message.subtype === 'bot_message') {
+      logger.debug(`Muted message from a bridged user ${message.username}: ${message.text}`);
+      return;
+    }
+
     const channelName = channel.is_channel ? `#${channel.name}` : channel.name;
     const ircChannel = this.channelMapping[channelName];
 
@@ -219,6 +228,8 @@ class Bot {
         this.ircClient.say(ircChannel, prelude);
       } else if (!message.subtype) {
         text = `<${user.name}> ${text}`;
+      } else if (message.subtype === 'bot_message') {
+        text = `<${message.username}> ${text}`;
       } else if (message.subtype === 'file_share') {
         text = `<${user.name}> File uploaded ${message.file.permalink} / ${message.file.permalink_public}`;
         if (message.file.initial_comment) {

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -35,7 +35,7 @@ class Bot {
     this.commandCharacters = options.commandCharacters || [];
     this.channels = _.values(options.channelMapping);
     this.muteSlackbot = options.muteSlackbot || false;
-    this.muteBridgedUsers = options.muteBridgedUsers || true;
+    this.muteBridgedUsers = options.muteBridgedUsers;
     this.muteUsers = {
       slack: [],
       irc: [],
@@ -206,14 +206,19 @@ class Bot {
 
     const user = dataStore.getUserById(message.user);
 
-    if (this.muteUsers.slack.indexOf(user.name) !== -1) {
+    if (user && this.muteUsers.slack.indexOf(user.name) !== -1) {
       logger.debug(`Muted message from Slack ${user.name}: ${message.text}`);
       return;
     }
 
-    if (this.muteBridgedUsers && message.subtype === 'bot_message') {
-      logger.debug(`Muted message from a bridged user ${message.username}: ${message.text}`);
-      return;
+    if (message.subtype === 'bot_message') {
+      if (message.username && message.username.search(/[(]IRC[)]/) !== -1) {
+        logger.debug(`Muted self-generated message ${message.username}: ${message.text}`);
+        return;
+      } else if (this.muteBridgedUsers === true) {
+        logger.debug(`Muted message from a bridged user ${message.username}: ${message.text} ${this.muteBridgedUsers} ${message.subtype}`);
+        return;
+      }
     }
 
     const channelName = channel.is_channel ? `#${channel.name}` : channel.name;

--- a/test/bot-events.test.js
+++ b/test/bot-events.test.js
@@ -107,6 +107,29 @@ describe('Bot Events', function () {
     this.bot.sendToIRC.should.have.not.have.been.called;
   });
 
+  it('should not send bot messages without usernames to irc', function () {
+    const message = {
+      type: 'message',
+      subtype: 'bot_message',
+      text: 'a message from a bot',
+      bot_id: 'ROBOT'
+    };
+    this.bot.slack.rtm.emit('message', message);
+    this.bot.sendToIRC.should.have.not.have.been.called;
+  });
+
+  it('should send bot messages with usernames to irc', function () {
+    const message = {
+      type: 'message',
+      subtype: 'bot_message',
+      text: 'a message from a user',
+      username: 'realuser',
+      bot_id: 'ROBOT'
+    };
+    this.bot.slack.rtm.emit('message', message);
+    this.bot.sendToIRC.should.have.have.been.called;
+  });
+
   it('should send messages to slack', function () {
     const channel = '#channel';
     const author = 'user';

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -310,6 +310,32 @@ describe('Bot', function () {
     ClientStub.prototype.say.should.not.have.been.called;
   });
 
+  it('should not send messages from bots with usernames if bridged user muting is on', function () {
+    this.bot.muteBridgedUsers = true;
+    const message = {
+      type: 'message',
+      subtype: 'bot_message',
+      bot_id: 'SOMEBOT',
+      username: 'someuser',
+      text: 'hello world!'
+    };
+    this.bot.sendToIRC(message);
+    ClientStub.prototype.say.should.not.have.been.called;
+  });
+
+  it('should send bot messages with usernames to irc', function () {
+    this.bot.muteBridgedUsers = false;
+    const message = {
+      type: 'message',
+      subtype: 'bot_message',
+      bot_id: 'SOMEBOT',
+      username: 'someuser',
+      text: 'hello world!'
+    };
+    this.bot.sendToIRC(message);
+    ClientStub.prototype.say.should.have.been.called;
+  });
+
   it('should parse text from slack when sending messages', function () {
     const text = '<@USOMEID> <@USOMEID|readable>';
     const message = {


### PR DESCRIPTION
To connect the Slack and IRC with other systems requires that bot messages that don't originate from the bot itself need to be relayed to IRC. This allows, for example, Telegram messages to be relayed via Slack to IRC.

Simple recursion is detected by checking if the username contains the `(IRC)` string.