### PR TITLE
Fix username sent to IRC : prefer display_name over user.name

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -213,19 +213,20 @@ class Bot {
     logger.debug('Channel Mapping', channelName, this.channelMapping[channelName]);
     if (ircChannel) {
       let text = this.parseText(message.text);
+      let dauser = user.profile.display_name ? user.profile.display_name : user.name;
 
       if (this.isCommandMessage(text)) {
-        const prelude = `Command sent from Slack by ${user.name}:`;
+        const prelude = `Command sent from Slack by ${dauser}:`;
         this.ircClient.say(ircChannel, prelude);
       } else if (!message.subtype) {
-        text = `<${user.name}> ${text}`;
+        text = `<${dauser}> ${text}`;
       } else if (message.subtype === 'file_share') {
-        text = `<${user.name}> File uploaded ${message.file.permalink} / ${message.file.permalink_public}`;
+        text = `<${dauser}> File uploaded ${message.file.permalink} / ${message.file.permalink_public}`;
         if (message.file.initial_comment) {
           text += ` - ${message.file.initial_comment.comment}`;
         }
       } else if (message.subtype === 'me_message') {
-        text = `Action: ${user.name} ${text}`;
+        text = `Action: ${dauser} ${text}`;
       }
       logger.debug('Sending message to IRC', channelName, text);
       this.ircClient.say(ircChannel, text);


### PR DESCRIPTION
Try to use display_name (often set to the user's nick) over user.name when it is set