### PR TITLE
Add readOnly flag to mute Slack messages

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -34,6 +34,7 @@ class Bot {
     this.ircStatusNotices = options.ircStatusNotices || {};
     this.commandCharacters = options.commandCharacters || [];
     this.channels = _.values(options.channelMapping);
+    this.readOnly = options.readOnly;
     this.muteSlackbot = options.muteSlackbot || false;
     this.muteUsers = {
       slack: [],
@@ -188,6 +189,10 @@ class Bot {
   }
 
   sendToIRC(message) {
+    if (this.readOnly) {
+      return;
+    }
+
     const { dataStore } = this.slack.rtm;
     const channel = dataStore.getChannelGroupOrDMById(message.channel);
     if (!channel) {

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -238,6 +238,22 @@ describe('Bot', function () {
     ClientStub.prototype.say.should.have.been.calledWith('#irc', ircText);
   });
 
+  it('should not send messages to irc if read-only', function () {
+    const customReadOnlyConfig = {
+      ...config,
+      readOnly: true
+    };
+    const bot = createBot(customReadOnlyConfig);
+    const text = 'testmessage';
+    const message = {
+      text,
+      channel: 'slack'
+    };
+
+    bot.sendToIRC(message);
+    ClientStub.prototype.say.should.not.have.been.called;
+  });
+
   it('should allow custom user formats for irc', function () {
     const customIRCUsernameFormatConfig = {
       ...config,


### PR DESCRIPTION
This new option allows for the creation of read-only Slack-IRC bridges, i.e. messages from Slack are not forwarded to IRC.