### PR TITLE
Added feature to create a connection per slack user

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -31,6 +31,7 @@ class Bot {
     this.server = options.server;
     this.nickname = options.nickname;
     this.ircOptions = options.ircOptions;
+    this.connectionPerUser = options.connectionPerUser || false;
     this.ircStatusNotices = options.ircStatusNotices || {};
     this.commandCharacters = options.commandCharacters || [];
     this.channels = _.values(options.channelMapping);
@@ -45,7 +46,10 @@ class Bot {
     // Disable if it's set to false, override default with custom if available:
     this.avatarUrl = options.avatarUrl !== false && (options.avatarUrl || defaultUrl);
     this.slackUsernameFormat = options.slackUsernameFormat || '$username (IRC)';
-    this.ircUsernameFormat = options.ircUsernameFormat == null ? '<$username> ' : options.ircUsernameFormat;
+    const baseIrcUsernameFormat = this.connectionPerUser ? '' : '<$username> ';
+    this.ircUsernameFormat = options.ircUsernameFormat == null ?
+        baseIrcUsernameFormat : options.ircUsernameFormat;
+    this.ircNickFormat = options.ircNickFormat ? options.ircNickFormat : '$username[s]';
     this.channelMapping = {};
 
     // Remove channel passwords from the mapping and lowercase IRC channel names
@@ -73,6 +77,88 @@ class Bot {
 
     this.ircClient = new irc.Client(this.server, this.nickname, ircOptions);
     this.attachListeners();
+
+    if (this.connectionPerUser) {
+      this.ircUserClients = {};
+    }
+  }
+
+  connectIrcUser(username) {
+    const ircNick = this.ircNickFormat.replace(/\$username/g, username);
+    const ircOptions = {
+      userName: ircNick,
+      realName: ircNick,
+      channels: this.channels,
+      floodProtection: true,
+      floodProtectionDelay: 500,
+      retryCount: 10,
+      ...this.ircOptions
+    };
+
+    // Create the connection and status object
+    const client = new irc.Client(this.server, ircNick, ircOptions);
+    this.ircUserClients[username] = {
+      connected: false,
+      irc: client,
+      queue: [],
+      joinedChannels: []
+    };
+
+    client.on('registered', () => {
+      // Mute this nick to prevent loops
+      this.muteUsers.irc.push(ircNick);
+      this.ircUserClients[username].connected = true;
+    });
+    client.on('error', (error) => {
+      logger.error('IRC user client error', error);
+    });
+    client.on('abort', () => {
+      logger.error(`Maximum IRC retry count reached for user ${username}, stopping (probably due to server restriction).`);
+
+      // Publishing queue with the default client
+      this.ircUserClients[username].queue.forEach((item) => {
+        this.ircClient.say(item.channel, `Proxied for ${ircNick} due to error: ${item.text}`);
+      });
+
+      // Remove from state
+      _.pull(this.muteUsers.irc, ircNick);
+      delete this.ircUserClients[username];
+    });
+    this.channels.forEach((channel) => {
+      client.once(`join${channel.toLowerCase()}`, () => {
+        this.ircUserClients[username].joinedChannels.push(channel);
+
+        // Replay queue
+        const queueItems = _.filter(this.ircUserClients[username].queue,
+                queueItem => queueItem.channel === channel);
+        queueItems.forEach((queueItem) => {
+          console.log('Replaying queue:', queueItem.channel, queueItem.text);
+          client.say(queueItem.channel, queueItem.text);
+        });
+        _.remove(this.ircUserClients[username].queue, queueItem => queueItem.channel === channel);
+      });
+    });
+  }
+
+  postOnIrc(username, channel, text) {
+    // If not connection per user, simply use default bot
+    if (!this.connectionPerUser) {
+      this.ircClient.say(channel, text);
+      return;
+    }
+
+    // Check for connection details
+    if (!(username in this.ircUserClients)) {
+      this.connectIrcUser(username);
+    }
+
+    // Check if the connection is established
+    if (this.ircUserClients[username].connected
+        && this.ircUserClients[username].joinedChannels.includes(channel)) {
+      this.ircUserClients[username].irc.say(channel, text);
+    } else {
+      this.ircUserClients[username].queue.push({ channel, text });
+    }
   }
 
   attachListeners() {
@@ -217,8 +303,8 @@ class Bot {
       let text = this.parseText(message.text);
 
       if (this.isCommandMessage(text)) {
-        const prelude = `Command sent from Slack by ${user.name}:`;
-        this.ircClient.say(ircChannel, prelude);
+        const prelude = this.connectionPerUser ? 'Command sent from Slack:' : `Command sent from Slack by ${user.name}:`;
+        this.postOnIrc(user.name, ircChannel, prelude);
       } else if (!message.subtype) {
         text = `${username}${text}`;
       } else if (message.subtype === 'file_share') {
@@ -230,7 +316,7 @@ class Bot {
         text = `Action: ${user.name} ${text}`;
       }
       logger.debug('Sending message to IRC', channelName, text);
-      this.ircClient.say(ircChannel, text);
+      this.postOnIrc(user.name, ircChannel, text);
     }
   }
 


### PR DESCRIPTION
I found a single connection from a bot, with the username in the message text to be cumbersome and bad for the readability of the message origin.

This PR adds the ability to create a new connection for every slack user, by using the slack username appended with `[s]` to indicate the slack integration. The behavior is now more like the behavior on slack, but restrictions from the IRC might apply (maximum connections per host).

A todo is of course tests, but first I would like to know if you would consider merging this feature, or if I should simply keep it in my own fork.