### PR TITLE
Publishing proper links to images shared from Slack to IRC

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -26,8 +26,13 @@ class Bot {
 
     const web = new WebClient(options.token);
     const rtm = new RtmClient(options.token, { dataStore: new MemoryDataStore() });
-    this.slack = { web, rtm };
-
+    if (options.user_token) {
+      const web_user = new WebClient(options.user_token);
+      this.slack = { web, web_user, rtm };
+      }
+    else {
+      this.slack = { web, rtm };
+      }
     this.server = options.server;
     this.nickname = options.nickname;
     this.ircOptions = options.ircOptions;
@@ -222,7 +227,13 @@ class Bot {
       } else if (!message.subtype) {
         text = `${username}${text}`;
       } else if (message.subtype === 'file_share') {
-        text = `${username}File uploaded ${message.file.permalink} / ${message.file.permalink_public}`;
+        if (this.slack.web_user) {
+          this.slack.web_user.files.sharedPublicURL(message.file.id);
+          text = `${username}File uploaded ${message.file.permalink_public}`;
+          }
+        else {
+          text = `${username}File uploaded ${message.file.permalink} / ${message.file.permalink_public}`;
+          }
         if (message.file.initial_comment) {
           text += ` - ${message.file.initial_comment.comment}`;
         }


### PR DESCRIPTION
As of now, bots can get public URLs for images - the problem is, images aren't automatically shared, so the public links are 404 - until somebody shares them. This effectively prohibits the majority of users on IRC side from seeing the uploaded images - they only see notifications sent by the bot, but visiting the link results in "File not found". This also makes the image link forwarding capability, as it is, kind of useless.

In order to share a file, you need to either go into image properties and press a "Get public link" button or call `files.sharedPublicURL` from Web API. The problem is - bots can't use `files.sharedPublicURL`, only users (or apps with appropriate scopes) can do that. So, I've added a capability of using a user token additionally - solely for generating proper, accessible links.