### PR TITLE
Colourise Slack usernames on IRC

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Valid JSON cannot contain comments, so remember to remove them first!
       "irc": ["irc-user"],
       "slack": ["slack-user"]
     },
-    "ircHighlightUsernames": true // Off by default, uses IRC colors to colorize Slack usernames on IRC
+    "ircColorizeUsernames": true // Off by default, uses IRC colors to colorize Slack usernames on IRC
   }
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ Valid JSON cannot contain comments, so remember to remove them first!
     "muteUsers": {
       "irc": ["irc-user"],
       "slack": ["slack-user"]
-    }
+    },
+    "ircHighlightUsernames": true // Off by default, uses IRC colors to colorize Slack usernames on IRC
   }
 ]
 ```

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -5,7 +5,7 @@ import { MemoryDataStore, RtmClient, WebClient } from '@slack/client';
 import { ConfigurationError } from './errors';
 import emojis from '../assets/emoji.json';
 import { validateChannelMapping } from './validators';
-import { highlightUsername, colourizeUsername } from './helpers';
+import { highlightUsername, colorizeUsername } from './helpers';
 
 const ALLOWED_SUBTYPES = ['me_message', 'file_share'];
 const REQUIRED_FIELDS = ['server', 'nickname', 'channelMapping', 'token'];
@@ -203,7 +203,7 @@ class Bot {
     }
 
     const user = dataStore.getUserById(message.user);
-    const username = this.ircUsernameFormat.replace(/\$username/g, this.ircColorizeUsernames ? colourizeUsername(user.name) : user.name);
+    const username = this.ircUsernameFormat.replace(/\$username/g, this.ircColorizeUsernames ? colorizeUsername(user.name) : user.name);
     if (this.muteUsers.slack.indexOf(user.name) !== -1) {
       logger.debug(`Muted message from Slack ${user.name}: ${message.text}`);
       return;
@@ -217,7 +217,7 @@ class Bot {
       let text = this.parseText(message.text);
 
       if (this.isCommandMessage(text)) {
-        const prelude = `Command sent from Slack by ${colourizeUsername(user.name)}:`;
+        const prelude = `Command sent from Slack by ${this.ircColorizeUsernames ? colorizeUsername(user.name) : user.name}:`;
         this.ircClient.say(ircChannel, prelude);
       } else if (!message.subtype) {
         text = `${username}${text}`;
@@ -227,7 +227,7 @@ class Bot {
           text += ` - ${message.file.initial_comment.comment}`;
         }
       } else if (message.subtype === 'me_message') {
-        text = `Action: ${irc.colourizeUsername ? colourizeUsername(user.name) : user.name} ${text}`;
+        text = `Action: ${this.ircColorizeUsernames ? colorizeUsername(user.name) : user.name} ${text}`;
       }
       logger.debug('Sending message to IRC', channelName, text);
       this.ircClient.say(ircChannel, text);

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -5,7 +5,7 @@ import { MemoryDataStore, RtmClient, WebClient } from '@slack/client';
 import { ConfigurationError } from './errors';
 import emojis from '../assets/emoji.json';
 import { validateChannelMapping } from './validators';
-import { highlightUsername } from './helpers';
+import { highlightUsername, colourizeUsername } from './helpers';
 
 const ALLOWED_SUBTYPES = ['me_message', 'file_share'];
 const REQUIRED_FIELDS = ['server', 'nickname', 'channelMapping', 'token'];
@@ -46,6 +46,7 @@ class Bot {
     this.avatarUrl = options.avatarUrl !== false && (options.avatarUrl || defaultUrl);
     this.slackUsernameFormat = options.slackUsernameFormat || '$username (IRC)';
     this.ircUsernameFormat = options.ircUsernameFormat == null ? '<$username> ' : options.ircUsernameFormat;
+    this.ircColorizeUsernames = options.ircHighlightUsernames || false;
     this.channelMapping = {};
 
     // Remove channel passwords from the mapping and lowercase IRC channel names
@@ -202,8 +203,7 @@ class Bot {
     }
 
     const user = dataStore.getUserById(message.user);
-    const username = this.ircUsernameFormat.replace(/\$username/g, user.name);
-
+    const username = this.ircUsernameFormat.replace(/\$username/g, this.ircColorizeUsernames ? colourizeUsername(user.name) : user.name);
     if (this.muteUsers.slack.indexOf(user.name) !== -1) {
       logger.debug(`Muted message from Slack ${user.name}: ${message.text}`);
       return;
@@ -217,7 +217,7 @@ class Bot {
       let text = this.parseText(message.text);
 
       if (this.isCommandMessage(text)) {
-        const prelude = `Command sent from Slack by ${user.name}:`;
+        const prelude = `Command sent from Slack by ${colourizeUsername(user.name)}:`;
         this.ircClient.say(ircChannel, prelude);
       } else if (!message.subtype) {
         text = `${username}${text}`;
@@ -227,7 +227,7 @@ class Bot {
           text += ` - ${message.file.initial_comment.comment}`;
         }
       } else if (message.subtype === 'me_message') {
-        text = `Action: ${user.name} ${text}`;
+        text = `Action: ${irc.colourizeUsername ? colourizeUsername(user.name) : user.name} ${text}`;
       }
       logger.debug('Sending message to IRC', channelName, text);
       this.ircClient.say(ircChannel, text);

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -46,7 +46,7 @@ class Bot {
     this.avatarUrl = options.avatarUrl !== false && (options.avatarUrl || defaultUrl);
     this.slackUsernameFormat = options.slackUsernameFormat || '$username (IRC)';
     this.ircUsernameFormat = options.ircUsernameFormat == null ? '<$username> ' : options.ircUsernameFormat;
-    this.ircColorizeUsernames = options.ircHighlightUsernames || false;
+    this.ircColorizeUsernames = options.ircColorizeUsernames || false;
     this.channelMapping = {};
 
     // Remove channel passwords from the mapping and lowercase IRC channel names

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -49,3 +49,18 @@ export function highlightUsername(user, text) {
     return word;
   }).join(' ');
 }
+
+/**
+ * Takes a plain username and returns it surrounded by color codes
+ * @param {string} user username to colourize
+ * @returns {string} colourized username string with mIRC color codes
+ */
+export function colourizeUsername(user) {
+  let hash = 5381;
+  for (let i = 0; i < user.length; i += 1) {
+    hash = (hash * 33) + user.charCodeAt(i);
+    // hash = ((hash << 5) + hash) + user.charCodeAt(i);
+  }
+  hash = Math.abs(hash);
+  return `\x03${hash % 16}${user}\x0F`;
+}

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -59,7 +59,6 @@ export function colorizeUsername(user) {
   let hash = 5381;
   for (let i = 0; i < user.length; i += 1) {
     hash = (hash * 33) + user.charCodeAt(i);
-    // hash = ((hash << 5) + hash) + user.charCodeAt(i);
   }
   hash = Math.abs(hash);
   return `\x03${hash % 16}${user}\x0F`;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -55,7 +55,7 @@ export function highlightUsername(user, text) {
  * @param {string} user username to colourize
  * @returns {string} colourized username string with mIRC color codes
  */
-export function colourizeUsername(user) {
+export function colorizeUsername(user) {
   let hash = 5381;
   for (let i = 0; i < user.length; i += 1) {
     hash = (hash * 33) + user.charCodeAt(i);


### PR DESCRIPTION
Uses IRC colours to show bridged Slack users' names in different colours. Styling is applied to `user.name`, so outer brackets (`< >`) or any custom formatting done by `ircUsernameFormat` is not coloured. Adds a JSON option "ircColorizeUsernames", which defaults to `false`. Code consistently uses US spelling ("colorize"). Tests pass with this PR (since it is off by default) , but I didn't write a test for this feature, so that could be added if necessary.