### PR TITLE
Remove IRC formatting (colors, bold, underline etc.)

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -183,6 +183,30 @@ class Bot {
       .replace(/&amp;/g, '&');
   }
 
+  removeIRCFormatting(text) {
+    return text
+      .replace(/\u000f/g, "") // format end
+      .replace(/\u0002/g, "") // bold
+      .replace(/\u0001f/g, "") // underline
+      .replace(/\u00016/g, "") // reverse
+      .replace(/\u000300/g, "") // colors
+      .replace(/\u000301/g, "")
+      .replace(/\u000302/g, "")
+      .replace(/\u000303/g, "")
+      .replace(/\u000304/g, "")
+      .replace(/\u000305/g, "")
+      .replace(/\u000306/g, "")
+      .replace(/\u000307/g, "")
+      .replace(/\u000308/g, "")
+      .replace(/\u000309/g, "")
+      .replace(/\u000310/g, "")
+      .replace(/\u000311/g, "")
+      .replace(/\u000312/g, "")
+      .replace(/\u000313/g, "")
+      .replace(/\u000314/g, "")
+      .replace(/\u000315/g, "");
+    }
+
   isCommandMessage(message) {
     return this.commandCharacters.indexOf(message[0]) !== -1;
   }
@@ -259,8 +283,8 @@ class Bot {
       );
 
       const mappedText = currentChannelUsernames.reduce((current, username) =>
-        highlightUsername(username, current)
-      , text);
+	highlightUsername(username, current)
+	, this.removeIRCFormatting(text));
 
       let iconUrl;
       if (author !== this.nickname && this.avatarUrl) {


### PR DESCRIPTION
Before sending IRC message to Slack, remove the formatting.