### PR TITLE
Bridge message event subtype 'thread_broadcast'

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -7,7 +7,7 @@ import emojis from '../assets/emoji.json';
 import { validateChannelMapping } from './validators';
 import { highlightUsername } from './helpers';
 
-const ALLOWED_SUBTYPES = ['me_message', 'file_share'];
+const ALLOWED_SUBTYPES = ['me_message', 'file_share', 'thread_broadcast'];
 const REQUIRED_FIELDS = ['server', 'nickname', 'channelMapping', 'token'];
 
 /**


### PR DESCRIPTION
Replies in a thread that are also sent to the Slack channel
weren't being forwarded to the IRC.